### PR TITLE
remove padding from divs in lightdom

### DIFF
--- a/sliding-pages.html
+++ b/sliding-pages.html
@@ -27,7 +27,6 @@
         display: block;
         position: absolute;
         opacity: 1;
-        padding: 8px;
         top: 0;
         left: 0;
         right: 0;


### PR DESCRIPTION
Removing the 8px padding from the slotted divs. It should be up to the user of the sliding-pages if a padding should be applied or not.